### PR TITLE
Updated the Dependabot configuration to increase the PR limit to 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,4 @@ updates:
     schedule:
       interval: "weekly"
       day: "saturday"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
I set the `open-pull-requests-limit` to 10 in the .github/dependabot.yml file. This will allow Dependabot to create more pull requests for dependency updates.