### PR TITLE
Update character types in crew manifest

### DIFF
--- a/src/services/crew-manifest.ts
+++ b/src/services/crew-manifest.ts
@@ -96,7 +96,7 @@ export class CrewManifest {
         homeworld: "Takodana",
         species: "Human",
         affiliation: "The Cause",
-        type: CrewMemberType.NPC,
+        type: CrewMemberType.Faction_Leader,
         image: "./crew/lias.jpg",
         alignment: ChainCodeAlignmentString.Neutral,
         meetingLocation:
@@ -195,7 +195,7 @@ export class CrewManifest {
         affiliation: "Alderaan first, then Resistance",
         npcLocation:
           "You can find Schme where the Outpost's favorite food is sold.",
-        type: CrewMemberType.Faction_Leader,
+        type: CrewMemberType.NPC,
         image: "./crew/schme.jpeg",
       }),
     );


### PR DESCRIPTION
Update character types in crew manifest

Change Lias Orion's type to Faction Leader and Schme Wilaka's type to NPC per user request.

---
*PR created automatically by Jules for task [11460340344222684194](https://jules.google.com/task/11460340344222684194) started by @josephrkramer*